### PR TITLE
Use rooted paths in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-servicebroker
-servicebroker-linux
-image/servicebroker
+/servicebroker
+/servicebroker-linux
+/image/servicebroker


### PR DESCRIPTION
Otherwise it is matching directories like ./cmd/servicebroker which probably wasn't intended.