### PR TITLE
Remove gopkg.in/yaml.v2 from manifest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d8c56317476078d2c104af8b35fb25c2c2cf9261ff49d4a62d1a664d8d0dbff2"
+  inputs-digest = "b122503b9aecccc06151c6c62a72ddefec1df2230ba29749be15d6ab9da361aa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,3 @@
 [[constraint]]
   branch = "master"
   name = "github.com/pmorie/go-open-service-broker-client"
-
-[[constraint]]
-  branch = "v2"
-  name = "gopkg.in/yaml.v2"


### PR DESCRIPTION
It is a transitive dependency and cannot be managed with dep without a hack. Since it resolves properly anyway to V2, it can be safely removed.

Fixes #46 