### PR TITLE
Remove user pkg dependency from rest pkg

### DIFF
--- a/cmd/servicebroker/main.go
+++ b/cmd/servicebroker/main.go
@@ -60,7 +60,12 @@ func runWithContext(ctx context.Context) error {
 
 	addr := ":" + strconv.Itoa(options.Port)
 
-	api, err := rest.NewAPISurface(options.Options)
+	businessLogic, err := user.NewBusinessLogic(options.Options)
+	if err != nil {
+		return err
+	}
+
+	api, err := rest.NewAPISurface(businessLogic)
 	if err != nil {
 		return err
 	}

--- a/pkg/rest/apisurface.go
+++ b/pkg/rest/apisurface.go
@@ -10,7 +10,6 @@ import (
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 
 	"github.com/pmorie/osb-starter-pack/pkg/broker"
-	"github.com/pmorie/osb-starter-pack/pkg/user"
 )
 
 // APISurface is a type that describes a OSB REST API surface. APISurface is
@@ -33,13 +32,7 @@ const (
 )
 
 // NewAPISurface returns a new, ready-to-go APISurface.
-func NewAPISurface(options user.Options) (*APISurface, error) {
-
-	businessLogic, err := user.NewBusinessLogic(options)
-	if err != nil {
-		return nil, err
-	}
-
+func NewAPISurface(businessLogic broker.BusinessLogic) (*APISurface, error) {
 	api := &APISurface{
 		BusinessLogic: businessLogic,
 	}


### PR DESCRIPTION
This will make it easy to separate the `rest` pkg from the osb-starter-pack to a separate lib.