### PR TITLE
Rename user pkg to broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ build the image, deploy the broker into your Kubernetes, and add a
 ## Adding your business logic
 
 To implement your broker, you fill out just a few methods and types in
-`pkg/user` package:
+`pkg/broker` package:
 
 - The `Options` type, which holds options for the broker
 - The `AddFlags` function, which adds CLI flags for an Options

--- a/cmd/servicebroker/main.go
+++ b/cmd/servicebroker/main.go
@@ -16,11 +16,11 @@ import (
 	"github.com/pmorie/osb-broker-lib/pkg/metrics"
 	"github.com/pmorie/osb-broker-lib/pkg/rest"
 	"github.com/pmorie/osb-broker-lib/pkg/server"
-	"github.com/pmorie/osb-starter-pack/pkg/user"
+	"github.com/pmorie/osb-starter-pack/pkg/broker"
 )
 
 var options struct {
-	user.Options
+	broker.Options
 
 	Port    int
 	TLSCert string
@@ -31,7 +31,7 @@ func init() {
 	flag.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
 	flag.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
 	flag.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
-	user.AddUserFlags(&options.Options)
+	broker.AddFlags(&options.Options)
 	flag.Parse()
 }
 
@@ -62,7 +62,7 @@ func runWithContext(ctx context.Context) error {
 
 	addr := ":" + strconv.Itoa(options.Port)
 
-	businessLogic, err := user.NewBusinessLogic(options.Options)
+	businessLogic, err := broker.NewBusinessLogic(options.Options)
 	if err != nil {
 		return err
 	}

--- a/pkg/broker/cli.go
+++ b/pkg/broker/cli.go
@@ -1,21 +1,21 @@
-package user
+package broker
 
 import (
 	"flag"
 )
 
-// Options holds the options specified by the user's code on the command
+// Options holds the options specified by the broker's code on the command
 // line. Users should add their own options here and add flags for them in
-// AddUserFlags.
+// AddFlags.
 type Options struct {
 	CatalogPath string
 	Async       bool
 }
 
-// AddUserFlags is a hook called to initialize the CLI flags for user options it
-// is called after the flags are added for the skeleton and before flag.Parse is
-// called.
-func AddUserFlags(o *Options) {
+// AddFlags is a hook called to initialize the CLI flags for broker options.
+// It is called after the flags are added for the skeleton and before flag
+// parse is called.
+func AddFlags(o *Options) {
 	flag.StringVar(&o.CatalogPath, "catalogPath", "", "The path to the catalog")
 	flag.BoolVar(&o.Async, "async", false, "Indicates whether the broker is handling the requests asynchronously.")
 }

--- a/pkg/broker/doc.go
+++ b/pkg/broker/doc.go
@@ -1,5 +1,5 @@
-// Package user holds the code that users of the skeleton write for their
-// broker.  To make a broker, fill out:
+// Package broker holds the code that users of the skeleton write for their
+// broker. To make a broker, fill out:
 //
 // - The Options type, which holds options for the broker
 // - The AddFlags function, which adds CLI flags for an Options
@@ -7,4 +7,4 @@
 //   business logic
 // - The NewBusinessLogic function, which creates a BusinessLogic from the
 //   Options the program is run with
-package user // import "github.com/pmorie/osb-starter-pack/pkg/user"
+package broker // import "github.com/pmorie/osb-starter-pack/pkg/broker"

--- a/pkg/broker/logic.go
+++ b/pkg/broker/logic.go
@@ -1,4 +1,4 @@
-package user
+package broker
 
 import (
 	"net/http"


### PR DESCRIPTION
As the other pkgs were separated to its own library it makes more sense
to call the `user` pkg `broker` instead. This also avoids the need for
the consumer to later rename the `user` pkg, as the name is generic
enough that it can be kept.

As agreed @pmorie this renames the `user` pkg to `broker`. Not sure `broker` is the best name, as there is the `broker` pkg in `github.com/pmorie/osb-broker-lib/pkg/broker` as well? WDYT?