### PR TITLE
serve securely with OpenShift generated certificates

### DIFF
--- a/cmd/servicebroker/main.go
+++ b/cmd/servicebroker/main.go
@@ -22,15 +22,21 @@ import (
 var options struct {
 	broker.Options
 
-	Port    int
-	TLSCert string
-	TLSKey  string
+	Port        int
+	Insecure    bool
+	TLSCert     string
+	TLSKey      string
+	TLSCertFile string
+	TLSKeyFile  string
 }
 
 func init() {
-	flag.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
-	flag.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
-	flag.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
+	flag.IntVar(&options.Port, "port", 8443, "use '--port' option to specify the port for broker to listen on")
+	flag.BoolVar(&options.Insecure, "insecure", false, "use --insecure to use HTTP vs HTTPS.")
+	flag.StringVar(&options.TLSCertFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert).")
+	flag.StringVar(&options.TLSKeyFile, "tls-private-key-file", "", "File containing the default x509 private key matching --tls-cert-file.")
+	flag.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used.")
+	flag.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate.")
 	broker.AddFlags(&options.Options)
 	flag.Parse()
 }
@@ -56,7 +62,7 @@ func runWithContext(ctx context.Context) error {
 	}
 	if (options.TLSCert != "" || options.TLSKey != "") &&
 		(options.TLSCert == "" || options.TLSKey == "") {
-		fmt.Println("To use TLS, both --tlsCert and --tlsKey must be used")
+		fmt.Println("To use TLS with specified cert or key data, both --tlsCert and --tlsKey must be used")
 		return nil
 	}
 
@@ -81,10 +87,20 @@ func runWithContext(ctx context.Context) error {
 
 	glog.Infof("Starting broker!")
 
-	if options.TLSCert == "" && options.TLSKey == "" {
+	if options.Insecure {
 		err = s.Run(ctx, addr)
 	} else {
-		err = s.RunTLS(ctx, addr, options.TLSCert, options.TLSKey)
+		if options.TLSCert != "" && options.TLSKey != "" {
+			glog.V(4).Infof("Starting secure broker with TLS cert and key data")
+			err = s.RunTLS(ctx, addr, options.TLSCert, options.TLSKey)
+		} else {
+			if options.TLSCertFile == "" || options.TLSKeyFile == "" {
+				glog.Error("unable to run securely without TLS Certificate and Key. Please review options and if running with TLS, specify --tls-cert-file and --tls-private-key-file or --tlsCert and --tlsKey.")
+				return nil
+			}
+			glog.V(4).Infof("Starting secure broker with file based TLS cert and key")
+			err = s.RunTLSWithTLSFiles(ctx, addr, options.TLSCertFile, options.TLSKeyFile)
+		}
 	}
 	return err
 }

--- a/openshift/starter-pack.yaml
+++ b/openshift/starter-pack.yaml
@@ -20,6 +20,8 @@ objects:
   apiVersion: v1
   metadata:
     name: osb-starter-pack
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: 'osb-starter-pack-ssl'
     labels:
       app: osb-starter-pack
   spec:
@@ -27,8 +29,8 @@ objects:
       app: osb-starter-pack
     ports:
     - protocol: TCP
-      port: 80
-      targetPort: 8080
+      port: 443
+      targetPort: 8443
 - kind: Deployment
   apiVersion: extensions/v1beta1
   metadata:
@@ -53,15 +55,19 @@ objects:
           - /opt/servicebroker/servicebroker
           args:
           - --port
-          - "8080"
+          - "8443"
           - -v
           - "4"
           - --logtostderr
+          - --tls-cert-file
+          - "/var/run/osb-starter-pack/starterpack.crt"
+          - --tls-private-key-file
+          - "/var/run/osb-starter-pack/starterpack.key"
           ports:
-          - containerPort: 8080
+          - containerPort: 8443
           readinessProbe:
             tcpSocket:
-              port: 8080
+              port: 8443
             failureThreshold: 1
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -69,12 +75,26 @@ objects:
             timeoutSeconds: 2
           livenessProbe:
             tcpSocket:
-              port: 8080
+              port: 8443
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
+          volumeMounts:
+          - mountPath: /var/run/osb-starter-pack
+            name: osb-starter-pack-ssl
+            readOnly: true
+        volumes:
+        - name: osb-starter-pack-ssl
+          secret:
+            defaultMode: 420
+            secretName: osb-starter-pack-ssl
+            items:
+            - key: tls.crt
+              path: starterpack.crt
+            - key: tls.key
+              path: starterpack.key
 
 parameters:
 - description: Name of the image to use


### PR DESCRIPTION
Requires https://github.com/pmorie/osb-broker-lib/pull/42 to be merged and starter pack to be revendored.

Use OpenShift's serving-cert-secret-name annotation off the server to auto generate SSL cert and key and default to running securely.  This PR only covers generating the ssl certificate files for OpenShift, I did not include changes for running under Kubernetes.

An easy follow up to "fix" Kubernetes is to add the --insecure flag to the helm chart so when run under K8s the default is to server insecurely.  Alternatively, Helm can created certificates.