### PR TITLE
instruct helm to create SSL cert & key, serve securely by default

### DIFF
--- a/charts/servicebroker/templates/broker-deployment.yaml
+++ b/charts/servicebroker/templates/broker-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - /opt/servicebroker/servicebroker
         args:
         - --port
-        - "8080"
+        - "8443"
         {{- if .Values.tls.cert}}
         - --tlsCert
         - "{{ .Values.tls.cert }}"
@@ -44,14 +44,31 @@ spec:
         - -v
         - "5"
         - -logtostderr
+        - --tls-cert-file
+        - "/var/run/osb-starter-pack/starterpack.crt"
+        - --tls-private-key-file
+        - "/var/run/osb-starter-pack/starterpack.key"
         ports:
-        - containerPort: 8080
+        - containerPort: 8443
         readinessProbe:
           tcpSocket:
-            port: 8080
+            port: 8443
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
-
+        volumeMounts:
+        - mountPath: /var/run/osb-starter-pack
+          name: osb-starter-pack-ssl
+          readOnly: true
+      volumes:
+      - name: osb-starter-pack-ssl
+        secret:
+          defaultMode: 420
+          secretName: broker-skeleton-broker-skeleton-osb-starter-pack-cert
+          items:
+          - key: tls.crt
+            path: starterpack.crt
+          - key: tls.key
+            path: starterpack.key

--- a/charts/servicebroker/templates/broker-service-account.yaml
+++ b/charts/servicebroker/templates/broker-service-account.yaml
@@ -38,6 +38,7 @@ subjects:
     name: {{ template "fullname" . }}-service
     namespace: {{ .Release.Name }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "fullname" . }}
 ---

--- a/charts/servicebroker/templates/broker-service.yaml
+++ b/charts/servicebroker/templates/broker-service.yaml
@@ -12,5 +12,5 @@ spec:
     app: {{ template "fullname" . }}
   ports:
   - protocol: TCP
-    port: 80
-    targetPort: 8080
+    port: 443
+    targetPort: 8443

--- a/charts/servicebroker/templates/broker.yaml
+++ b/charts/servicebroker/templates/broker.yaml
@@ -4,10 +4,11 @@ kind: ClusterServiceBroker
 metadata:
   name: broker-skeleton
 spec:
-  url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-  authInfo:
-    bearer:
-      secretRef:
-        namespace: {{.Release.Namespace}}
-        name: {{ template "fullname" . }}
+  url: https://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  insecureSkipTLSVerify: true
+#  authInfo:
+#    bearer:
+#      secretRef:
+#        namespace: {{.Release.Namespace}}
+#        name: {{ template "fullname" . }}
 {{- end }}

--- a/charts/servicebroker/templates/broker.yaml
+++ b/charts/servicebroker/templates/broker.yaml
@@ -3,12 +3,17 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
   name: broker-skeleton
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
 spec:
   url: https://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   insecureSkipTLSVerify: true
-#  authInfo:
-#    bearer:
-#      secretRef:
-#        namespace: {{.Release.Namespace}}
-#        name: {{ template "fullname" . }}
+{{- if .Values.authenticate}}
+  authInfo:
+    bearer:
+      secretRef:
+        namespace: {{.Release.Namespace}}
+        name: {{ template "fullname" . }}
+{{- end }}
 {{- end }}

--- a/charts/servicebroker/templates/ssl-certs.yaml
+++ b/charts/servicebroker/templates/ssl-certs.yaml
@@ -1,0 +1,19 @@
+{{- $ca := genCA "svc-cat-ca" 3650 }}
+{{- $cn := printf "%s-osb-starter-pack" .Release.Name }}
+{{- $altName1 := printf "%s-osb-starter-pack.%s" .Release.Name .Release.Namespace }}
+{{- $altName2 := printf "%s-osb-starter-pack.%s.svc" .Release.Name .Release.Namespace }}
+{{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-osb-starter-pack-cert
+  labels:
+    app: {{ template "fullname" . }}-osb-starter-pack
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+  

--- a/charts/servicebroker/values.yaml
+++ b/charts/servicebroker/values.yaml
@@ -3,7 +3,7 @@
 image: quay.io/osb-starter-pack/servicebroker:latest
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
-authenticate: false
+authenticate: true
 # Certificate details to use for TLS. Leave blank to not use TLS
 tls:
   # base-64 encoded PEM data for the TLS certificate

--- a/charts/servicebroker/values.yaml
+++ b/charts/servicebroker/values.yaml
@@ -3,7 +3,7 @@
 image: quay.io/osb-starter-pack/servicebroker:latest
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
-authenticate: true
+authenticate: false
 # Certificate details to use for TLS. Leave blank to not use TLS
 tls:
   # base-64 encoded PEM data for the TLS certificate


### PR DESCRIPTION
closes https://github.com/pmorie/osb-starter-pack/issues/87 
closes https://github.com/pmorie/osb-starter-pack/issues/73
closes https://github.com/pmorie/osb-starter-pack/issues/95

follow on to https://github.com/pmorie/osb-starter-pack/pull/90.   This too requires picking up 0.0.8 of broker lib.

Helm will create kubernetes secret with SSL cert & key for the broker service and these will be unpacked and used by broker service for serving over HTTPS.

I see that the broker server pod is logging errors from health/readiness checks:
```TLS handshake error from 172.17.0.1:44734: EOF```

We should change readiness & health from tcpSocket to httpGet where you can specify scheme to be HTTPS.