### PR TITLE
Changed 'make deploy-openshift' command to switch to osb-starter-pack…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ deploy-helm: image ## Deploys image with helm
 	--set image="$(IMAGE):$(TAG)",imagePullPolicy="$(PULL)"
 
 deploy-openshift: image ## Deploys image to openshift
-	oc get project osb-starter-pack || oc new-project osb-starter-pack
+	oc project osb-starter-pack || oc new-project osb-starter-pack
 	openshift/deploy.sh $(IMAGE):$(TAG)
 
 create-ns: ## Cleans up the namespaces


### PR DESCRIPTION
… namespace if it already exists.

Came across this issue when testing the broker. If the namespace `osb-starter-pack` already exists, the command `oc get project osb-starter-pack` is run. This only checks that the project exists, rather than switching to the project namespace like the backup command `oc new-project osb-starter-pack` 

Gist of Issue:
```
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# oc new-project osb-starter-pack
Now using project "osb-starter-pack" on server "https://127.0.0.1:8443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git

to build a new example application in Ruby.
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# oc project myproject
Now using project "myproject" on server "https://127.0.0.1:8443".
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# make deploy-openshift
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
go build -o servicebroker-linux --ldflags="-s" github.com/pmorie/osb-starter-pack/cmd/servicebroker
cp servicebroker-linux image/servicebroker
docker build image/ -t "quay.io/osb-starter-pack/servicebroker:0.0.1-15-g161a811"
Sending build context to Docker daemon  21.55MB
Step 1/3 : FROM busybox
 ---> 5b0d59026729
Step 2/3 : ADD servicebroker /opt/servicebroker/servicebroker
 ---> Using cache
 ---> 8f1686bc0c43
Step 3/3 : CMD /opt/servicebroker/servicebroker --help
 ---> Using cache
 ---> b5012253ae84
Successfully built b5012253ae84
Successfully tagged quay.io/osb-starter-pack/servicebroker:0.0.1-15-g161a811
oc get project osb-starter-pack || oc new-project osb-starter-pack
NAME               DISPLAY NAME   STATUS
osb-starter-pack                  Active
openshift/deploy.sh quay.io/osb-starter-pack/servicebroker:0.0.1-15-g161a811
serviceaccount "osb-starter-pack-client" created
secret "osb-starter-pack" created
clusterservicebroker "osb-starter-pack" created
serviceaccount "osb-starter-pack" created
clusterrole "osb-starter-pack" created
clusterrolebinding "osb-starter-pack" created
service "osb-starter-pack" created
deployment "osb-starter-pack" created
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# oc project
Using project "myproject" on server "https://127.0.0.1:8443".
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# oc get pods
NAME                               READY     STATUS    RESTARTS   AGE
osb-starter-pack-5d67c8565-9tgr8   0/1       Running   0          11s
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# oc logs -f deployments/osb-starter-pack
I0424 23:44:43.218663       1 main.go:109] Starting broker!
I0424 23:44:43.219466       1 main.go:122] Starting secure broker with file based TLS cert and key
I0424 23:44:43.219475       1 server.go:110] Starting server on :8443
^C # Left this following for about a minute without any changes; the example service doesn't spawn.
root@sami-VirtualBox:/usr/local/go/src/github.com/pmorie/osb-starter-pack# oc get clusterservicebroker -o yaml
apiVersion: v1
items:
- apiVersion: servicecatalog.k8s.io/v1beta1
  kind: ClusterServiceBroker
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"servicecatalog.k8s.io/v1beta1","kind":"ClusterServiceBroker","metadata":{"annotations":{},"name":"osb-starter-pack","namespace":""},"spec":{"authInfo":{"bearer":{"secretRef":{"name":"osb-starter-pack","namespace":"osb-starter-pack"}}},"caBundle":"[redacted]","url":"https://osb-starter-pack.osb-starter-pack.svc.cluster.local"}}
    creationTimestamp: 2018-04-24T23:44:41Z
    finalizers:
    - kubernetes-incubator/service-catalog
    generation: 1
    name: osb-starter-pack
    namespace: ""
    resourceVersion: "80"
    selfLink: /apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/osb-starter-pack
    uid: 75418376-4819-11e8-a0e8-0242ac110006
  spec:
    authInfo:
      bearer:
        secretRef:
          name: osb-starter-pack
          namespace: osb-starter-pack
    caBundle: [redacted]
    relistBehavior: Duration
    relistDuration: 15m0s
    relistRequests: 0
    url: https://osb-starter-pack.osb-starter-pack.svc.cluster.local
  status:
    conditions:
    - lastTransitionTime: 2018-04-24T23:44:41Z
      message: 'Error fetching catalog. Error getting broker auth credentials: secrets
        "osb-starter-pack" not found'
      reason: ErrorFetchingCatalog
      status: "False"
      type: Ready
    reconciledGeneration: 0
...
```