### PR TITLE
Change ClusterServiceBroker install hook to crd-install type

### DIFF
--- a/charts/servicebroker/templates/broker.yaml
+++ b/charts/servicebroker/templates/broker.yaml
@@ -4,8 +4,7 @@ kind: ClusterServiceBroker
 metadata:
   name: broker-skeleton
   annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "5"
+    "helm.sh/hook": crd-install
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}--{{ .Chart.Version }}"


### PR DESCRIPTION
Helm was failing to deploy the chart with the post-install hook.
The chart deployed successfully after changing to the crd-install type.

Fixes #104 